### PR TITLE
Add sandbox rebuild command and clarify sandbox architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ OpenClawOrb/
 ├── templates/
 │   └── openclaw.json.example     # Config template (JSON5, 899 lines)
 ├── docs/
-│   ├── commands.md               # CLI reference (11 Mac + 150 official)
+│   ├── commands.md               # CLI reference (12 Mac + 150 official)
 │   ├── architecture.md           # System diagrams
 │   ├── configuration-guide.md    # Config guide (Chinese)
 │   ├── sandbox.md                # Sandbox security model
@@ -70,7 +70,7 @@ OpenClawOrb/
 | Gateway command | `node dist/entry.js gateway --port 18789` |
 | Node.js version | 22.x LTS |
 
-## Mac Commands (11)
+## Mac Commands (12)
 
 | Command | Function |
 |---------|----------|
@@ -83,7 +83,8 @@ OpenClawOrb/
 | `openclaw-restart` | Restart service |
 | `openclaw-stop/start` | Stop/start service |
 | `openclaw-shell` | Enter VM terminal |
-| `openclaw-update` | Update version |
+| `openclaw-update` | Update app (--sandbox to rebuild images) |
+| `openclaw-sandbox-rebuild` | Rebuild sandbox Docker images |
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ openclaw doctor
 | `openclaw-restart` | Restart service |
 | `openclaw-stop/start` | Stop/start service |
 | `openclaw-shell` | Enter VM terminal |
-| `openclaw-update` | Update version |
+| `openclaw-update` | Update app (`--sandbox` to rebuild images) |
+| `openclaw-sandbox-rebuild` | Rebuild sandbox Docker images |
 
 Full command reference: [docs/commands.md](docs/commands.md)
 
@@ -129,6 +130,7 @@ Full troubleshooting guide: [docs/troubleshooting.md](docs/troubleshooting.md)
 | Port 18789 in use | `sudo pkill -9 openclaw && sudo systemctl start openclaw` |
 | Memory directory error | `mkdir -p ~/.openclaw/memory` |
 | Memory search not working | Add OpenAI/Google key to agent auth-profiles.json |
+| Mac commands outdated | `cd openclaw-orbstack && git pull && bash scripts/refresh-mac-commands.sh` |
 
 ## Documentation
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -94,7 +94,8 @@ openclaw doctor
 | `openclaw-restart` | 重启服务 |
 | `openclaw-stop/start` | 停止/启动服务 |
 | `openclaw-shell` | 进入 VM |
-| `openclaw-update` | 更新版本 |
+| `openclaw-update` | 更新版本 (仅应用，`--sandbox` 重建镜像) |
+| `openclaw-sandbox-rebuild` | 重建沙箱镜像 |
 
 完整命令参考见 [commands.md](commands.md)
 
@@ -129,6 +130,7 @@ openclaw-shell         # 进入 VM 排查
 | Port 18789 already in use | `sudo pkill -9 openclaw && sudo systemctl start openclaw` |
 | Memory 目录错误 | `mkdir -p ~/.openclaw/memory` |
 | Memory search 无法使用 | 在 agent auth-profiles.json 中添加 OpenAI/Google key |
+| Mac 端命令过旧 | `cd openclaw-orbstack && git pull && bash scripts/refresh-mac-commands.sh` |
 
 ### Memory 目录问题
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,9 +105,9 @@
     │   git clone + npm install + npm run build
     ▼
 步骤 6: 构建沙箱镜像
-    │   ├── openclaw-sandbox:bookworm-slim
-    │   ├── openclaw-sandbox-browser:bookworm-slim
-    │   └── openclaw-sandbox-common:bookworm-slim
+    │   ├── openclaw-sandbox:bookworm-slim        (基础镜像，构建依赖)
+    │   ├── openclaw-sandbox-common:bookworm-slim  (基于基础镜像 + 开发工具)
+    │   └── openclaw-sandbox-browser:bookworm-slim (独立构建，Chromium)
     ▼
 步骤 7: 运行配置向导
     │   ./openclaw setup (交互式)
@@ -174,7 +174,8 @@
   ├── openclaw-start         # systemctl start
   ├── openclaw-shell         # 进入 VM
   ├── openclaw-doctor        # 运行诊断
-  └── openclaw-update        # 更新版本
+  ├── openclaw-update        # 更新版本 (仅应用，--sandbox 重建镜像)
+  └── openclaw-sandbox-rebuild # 重建沙箱镜像
 ```
 
 ## Gateway 与沙箱的通信

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,12 +4,12 @@
 
 在 Mac 上有两类命令可用：
 
-1. **OrbStack 管理命令** (`openclaw-*`) - 我们为 OrbStack 架构添加的 11 个命令
+1. **OrbStack 管理命令** (`openclaw-*`) - 我们为 OrbStack 架构添加的 12 个命令
 2. **官方 CLI 命令** (`openclaw <command>`) - 透传到 VM 的 150+ 官方命令
 
 ---
 
-## OrbStack 管理命令 (11 个)
+## OrbStack 管理命令 (12 个)
 
 这些命令在 `~/bin/` 目录下，用于管理 OrbStack VM 和服务：
 
@@ -60,18 +60,31 @@ openclaw-whatsapp                      # 扫码登录
 | `openclaw-stop` | 停止服务 |
 | `openclaw-start` | 启动服务 |
 | `openclaw-shell` | 进入 VM 终端 |
-| `openclaw-update` | 更新到最新版本 |
+| `openclaw-update` | 更新版本 (仅应用，`--sandbox` 重建镜像) |
+| `openclaw-sandbox-rebuild` | 重建沙箱 Docker 镜像 |
 
 ### 更新命令详情
 
-`openclaw-update` 执行以下步骤：
+`openclaw-update` 默认只更新应用（不重建沙箱镜像）：
 1. 停止 Gateway 服务
 2. 拉取最新代码 (`git pull`)
 3. 安装依赖 (`npm install`)
 4. 编译项目 (`npm run build`)
-5. 重新安装 CLI (`npm install -g .`)
-6. 更新沙箱镜像
+5. 构建 Control UI (`pnpm ui:build`)
+6. 重新安装 CLI (`npm install -g .`)
 7. 启动服务
+
+使用 `--sandbox` 标志同时重建沙箱镜像：
+```bash
+openclaw-update --sandbox
+```
+
+或单独重建沙箱镜像：
+```bash
+openclaw-sandbox-rebuild
+```
+
+> 沙箱镜像很少需要更新，只在上游 Dockerfile 变化时需要。已运行的容器仍使用旧镜像，需重启后生效。
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -119,7 +119,7 @@ bash openclaw-orbstack-setup.sh  # Fresh install
 | EBUSY on rename | Bind mount conflict | Script sets `OPENCLAW_STATE_DIR` |
 | Container won't start | Config merge failed | Check `openclaw-logs` |
 | Sandbox tools fail | Wrong image | Verify `common` image is used |
-| Browser tool fails | Browser sandbox not built | Rebuild with `sandbox-browser-setup.sh` |
+| Browser tool fails | Browser sandbox not built | Run `openclaw-sandbox-rebuild` or `sandbox-browser-setup.sh` |
 
 ### Debug Mode
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -33,9 +33,9 @@
 
 **沙箱是 AI 的"手"**——当 AI 说"我要执行这段代码"，Gateway 把请求发到代码沙箱执行，然后把结果返回给云端 AI。
 
-## 两个沙箱 (不是三个！)
+## 两个沙箱容器，三个 Docker 镜像
 
-系统只有**两个**沙箱容器，配置名称可能有歧义：
+运行时只有**两个**沙箱容器，但构建了**三个** Docker 镜像（基础镜像是 common 的构建依赖）：
 
 | 配置节 | 容器名 | 用途 |
 |--------|--------|------|
@@ -85,10 +85,10 @@
 │  │  - capDrop: ALL                 │  │                                 │  │
 │  └─────────────────────────────────┘  └─────────────────────────────────┘  │
 │                                                                              │
-│  构建的沙箱镜像:                                                              │
-│  1. openclaw-sandbox:bookworm-slim        - 最小基础镜像                     │
-│  2. openclaw-sandbox-common:bookworm-slim - 带开发工具 (默认)                │
-│  3. openclaw-sandbox-browser:bookworm-slim - 带 Chromium 浏览器              │
+│  构建的沙箱镜像 (3 个镜像，2 个运行时容器):                                    │
+│  1. openclaw-sandbox:bookworm-slim        - 基础镜像 (构建依赖，不直接使用)  │
+│  2. openclaw-sandbox-common:bookworm-slim - 基于 1 + 开发工具 (代码执行)     │
+│  3. openclaw-sandbox-browser:bookworm-slim - 独立构建，带 Chromium (浏览器)   │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -221,11 +221,11 @@ Docker 容器看不到！只能看到 /workspace
 
 ## 沙箱镜像
 
-| 镜像 | 内容 | 使用场景 |
-|------|------|----------|
-| `openclaw-sandbox:bookworm-slim` | 最小 Debian | 最高安全性，基础任务 |
-| `openclaw-sandbox-common:bookworm-slim` | + Node, Python, Go, Rust, git | **默认** - 开发任务 |
-| `openclaw-sandbox-browser:bookworm-slim` | + Chromium, CDP, Xvfb | 网页自动化 (独立容器) |
+| 镜像 | 内容 | 角色 |
+|------|------|------|
+| `openclaw-sandbox:bookworm-slim` | 最小 Debian (bash, curl, git, jq) | **构建依赖** — sandbox-common 的基础层 |
+| `openclaw-sandbox-common:bookworm-slim` | 基于上层 + Node, Python, Go, Rust | **运行时** — 代码执行沙箱 (`sandbox.docker`) |
+| `openclaw-sandbox-browser:bookworm-slim` | 独立构建，Chromium, CDP, Xvfb | **运行时** — 浏览器沙箱 (`sandbox.browser`) |
 
 ## 浏览器沙箱配置
 

--- a/scripts/refresh-mac-commands.sh
+++ b/scripts/refresh-mac-commands.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+set -e
+
+# 重新生成 Mac 端 ~/bin/openclaw-* 便捷命令
+# 适用于已部署用户更新命令脚本（不影响 VM 和沙箱）
+#
+# 用法:
+#   cd openclaw-orbstack && git pull && bash scripts/refresh-mac-commands.sh
+
+echo "🔄 正在重新生成 Mac 端便捷命令..."
+
+mkdir -p ~/bin
+
+cat > ~/bin/openclaw-status << 'EOF'
+#!/bin/bash
+orb -m openclaw-vm bash -c "systemctl status openclaw"
+EOF
+
+cat > ~/bin/openclaw-logs << 'EOF'
+#!/bin/bash
+orb -m openclaw-vm bash -c "journalctl -u openclaw -f"
+EOF
+
+cat > ~/bin/openclaw-restart << 'EOF'
+#!/bin/bash
+orb -m openclaw-vm bash -c "cd ~/openclaw && node dist/entry.js gateway restart"
+EOF
+
+cat > ~/bin/openclaw-stop << 'EOF'
+#!/bin/bash
+orb -m openclaw-vm bash -c "cd ~/openclaw && node dist/entry.js gateway stop"
+EOF
+
+cat > ~/bin/openclaw-start << 'EOF'
+#!/bin/bash
+orb -m openclaw-vm bash -c "cd ~/openclaw && node dist/entry.js gateway start"
+EOF
+
+cat > ~/bin/openclaw-shell << 'EOF'
+#!/bin/bash
+orb -m openclaw-vm
+EOF
+
+cat > ~/bin/openclaw << 'EOF'
+#!/bin/bash
+# OpenClaw CLI - 透传到 VM 的官方 CLI
+if [ $# -eq 0 ]; then
+    set -- "--help"
+fi
+orb -m openclaw-vm bash -c "openclaw $*"
+EOF
+
+cat > ~/bin/openclaw-config << 'EOF'
+#!/bin/bash
+ACTION="${1:-edit}"
+CONFIG_PATH="$HOME/.openclaw/openclaw.json"
+
+case "$ACTION" in
+    edit)
+        echo "正在打开配置编辑器..."
+        orb -m openclaw-vm bash -c "nano ~/.openclaw/openclaw.json 2>/dev/null || vi ~/.openclaw/openclaw.json"
+        echo "配置已保存。运行 openclaw-restart 使更改生效。"
+        ;;
+    show)
+        orb -m openclaw-vm bash -c "cat ~/.openclaw/openclaw.json"
+        ;;
+    backup)
+        BACKUP="openclaw-config-$(date +%Y%m%d-%H%M%S).json"
+        orb -m openclaw-vm bash -c "cat ~/.openclaw/openclaw.json" > "$BACKUP"
+        echo "已备份到: $BACKUP"
+        ;;
+    *)
+        echo "用法: openclaw-config [edit|show|backup]"
+        ;;
+esac
+EOF
+
+cat > ~/bin/openclaw-update << 'EOF'
+#!/bin/bash
+set -e
+
+SANDBOX=false
+for arg in "$@"; do
+    case "$arg" in
+        --sandbox) SANDBOX=true ;;
+        --help|-h)
+            echo "用法: openclaw-update [--sandbox]"
+            echo ""
+            echo "更新 OpenClaw 应用到最新版本。"
+            echo ""
+            echo "选项:"
+            echo "  --sandbox    同时重建沙箱 Docker 镜像"
+            echo ""
+            echo "提示: 单独重建沙箱可用 openclaw-sandbox-rebuild"
+            exit 0
+            ;;
+    esac
+done
+
+echo "🔄 正在更新 OpenClaw..."
+
+echo "  停止服务..."
+orb -m openclaw-vm bash -c "sudo systemctl stop openclaw"
+
+echo "  拉取最新代码..."
+orb -m openclaw-vm bash -c "cd ~/openclaw && git pull"
+
+echo "  安装依赖..."
+orb -m openclaw-vm bash -c "cd ~/openclaw && npm install"
+
+echo "  编译项目..."
+orb -m openclaw-vm bash -c "cd ~/openclaw && npm run build"
+
+echo "  构建 Control UI..."
+orb -m openclaw-vm bash -c "cd ~/openclaw && pnpm ui:build"
+
+echo "  重新安装 CLI..."
+orb -m openclaw-vm bash -c "cd ~/openclaw && sudo npm install -g ."
+
+if [ "$SANDBOX" = true ]; then
+    echo "  重建沙箱镜像..."
+    echo "    构建基础镜像..."
+    orb -m openclaw-vm bash -c "cd ~/openclaw && sg docker -c './scripts/sandbox-setup.sh'" 2>/dev/null || true
+    echo "    构建 common 镜像..."
+    orb -m openclaw-vm bash -c "cd ~/openclaw && sg docker -c './scripts/sandbox-common-setup.sh'" 2>/dev/null || true
+    echo "    构建浏览器镜像..."
+    orb -m openclaw-vm bash -c "cd ~/openclaw && sg docker -c './scripts/sandbox-browser-setup.sh'" 2>/dev/null || true
+    echo "  💡 已运行的容器仍使用旧镜像，重启后生效"
+fi
+
+echo "  启动服务..."
+orb -m openclaw-vm bash -c "sudo systemctl start openclaw"
+
+echo "✅ 更新完成！"
+if [ "$SANDBOX" = false ]; then
+    echo "💡 如需重建沙箱镜像: openclaw-update --sandbox"
+fi
+EOF
+
+cat > ~/bin/openclaw-sandbox-rebuild << 'EOF'
+#!/bin/bash
+set -e
+echo "🔨 正在重建沙箱 Docker 镜像..."
+
+# 基础镜像必须先构建（sandbox-common 依赖它）
+echo "  构建基础沙箱镜像..."
+if orb -m openclaw-vm bash -c "cd ~/openclaw && sg docker -c './scripts/sandbox-setup.sh'" 2>/dev/null; then
+    echo "  ✓ sandbox 基础镜像构建完成"
+elif orb -m openclaw-vm bash -c "cd ~/openclaw && sg docker -c 'docker build -t openclaw-sandbox:bookworm-slim -f Dockerfile.sandbox .'" 2>/dev/null; then
+    echo "  ✓ sandbox 基础镜像构建完成 (Dockerfile)"
+else
+    echo "  ✗ sandbox 基础镜像构建失败（sandbox-common 可能也会失败）"
+fi
+
+echo "  构建 common 沙箱镜像..."
+if orb -m openclaw-vm bash -c "cd ~/openclaw && sg docker -c './scripts/sandbox-common-setup.sh'" 2>/dev/null; then
+    echo "  ✓ sandbox-common 镜像构建完成"
+else
+    echo "  ✗ sandbox-common 镜像构建失败"
+fi
+
+echo "  构建浏览器沙箱镜像..."
+if orb -m openclaw-vm bash -c "cd ~/openclaw && sg docker -c './scripts/sandbox-browser-setup.sh'" 2>/dev/null; then
+    echo "  ✓ sandbox-browser 镜像构建完成"
+elif orb -m openclaw-vm bash -c "cd ~/openclaw && sg docker -c 'docker build -t openclaw-sandbox-browser:bookworm-slim -f Dockerfile.sandbox-browser .'" 2>/dev/null; then
+    echo "  ✓ sandbox-browser 镜像构建完成 (Dockerfile)"
+else
+    echo "  ✗ sandbox-browser 镜像构建失败"
+fi
+
+echo ""
+echo "✅ 沙箱镜像重建完成！"
+echo "💡 已运行的容器仍使用旧镜像，运行 openclaw-restart 使新镜像生效"
+EOF
+
+cat > ~/bin/openclaw-telegram << 'EOF'
+#!/bin/bash
+# Telegram Bot 管理
+ACTION="${1:-help}"
+
+case "$ACTION" in
+    add)
+        if [ -z "$2" ]; then
+            echo "用法: openclaw-telegram add <bot_token>"
+            echo "从 @BotFather 获取 token"
+            exit 1
+        fi
+        orb -m openclaw-vm bash -c "openclaw channels add --channel telegram --token $2"
+        ;;
+    approve)
+        if [ -z "$2" ]; then
+            echo "用法: openclaw-telegram approve <pairing_code>"
+            echo "输入 Bot 发给你的配对码"
+            exit 1
+        fi
+        orb -m openclaw-vm bash -c "openclaw pairing approve telegram $2"
+        ;;
+    *)
+        echo "Telegram Bot 管理"
+        echo ""
+        echo "用法:"
+        echo "  openclaw-telegram add <bot_token>      添加 Bot (从 @BotFather 获取)"
+        echo "  openclaw-telegram approve <code>       批准配对 (回执验证码)"
+        echo ""
+        echo "或直接使用:"
+        echo "  openclaw channels login --channel telegram"
+        ;;
+esac
+EOF
+
+cat > ~/bin/openclaw-whatsapp << 'EOF'
+#!/bin/bash
+# WhatsApp 登录 (扫码)
+orb -m openclaw-vm bash -c "openclaw channels login --channel whatsapp"
+EOF
+
+chmod +x ~/bin/openclaw-*
+chmod +x ~/bin/openclaw
+
+echo "✅ Mac 端便捷命令已更新！"
+echo ""
+echo "已生成以下命令:"
+echo "  openclaw                CLI 透传"
+echo "  openclaw-status         服务状态"
+echo "  openclaw-logs           实时日志"
+echo "  openclaw-restart        重启服务"
+echo "  openclaw-stop/start     停止/启动"
+echo "  openclaw-shell          进入 VM"
+echo "  openclaw-config         配置管理"
+echo "  openclaw-update         更新版本"
+echo "  openclaw-sandbox-rebuild 重建沙箱镜像"
+echo "  openclaw-telegram       Telegram 管理"
+echo "  openclaw-whatsapp       WhatsApp 登录"
+echo ""
+echo "确保 ~/bin 在 PATH 中: export PATH=\"\$HOME/bin:\$PATH\""

--- a/templates/openclaw.json.example
+++ b/templates/openclaw.json.example
@@ -185,9 +185,13 @@
       // 重要概念:
       // - AI 大脑运行在云端 (Anthropic/OpenAI/Google)，不在沙箱里
       // - 沙箱是 AI 的"手"——只执行工具，不运行 AI
-      // - 系统有两个沙箱:
+      // - 运行时有两个沙箱容器:
       //   1. sandbox.docker  → 代码执行沙箱 (exec, read, write, edit)
       //   2. sandbox.browser → 浏览器沙箱 (Playwright, Chromium)
+      // - 构建时有三个 Docker 镜像:
+      //   1. openclaw-sandbox:bookworm-slim        → 基础镜像 (构建依赖)
+      //   2. openclaw-sandbox-common:bookworm-slim  → 基于 1 + 开发工具 (代码执行用)
+      //   3. openclaw-sandbox-browser:bookworm-slim → 独立构建 (浏览器用)
       sandbox: {
         // 沙箱模式:
         //   "off"      - 不使用沙箱 (危险：AI 可访问 /mnt/mac)


### PR DESCRIPTION
## Summary
This PR adds a new `openclaw-sandbox-rebuild` command for Mac users and clarifies the sandbox architecture documentation. It separates sandbox image rebuilding from the general update process, making it easier for users to understand and manage sandbox images independently.

## Key Changes

### New Command
- **`openclaw-sandbox-rebuild`**: Dedicated command to rebuild all three sandbox Docker images (base, common, and browser) without updating the application code
- Updated `openclaw-update` to accept optional `--sandbox` flag for rebuilding images during updates
- Default behavior of `openclaw-update` now only updates the application (not sandbox images)

### Documentation Improvements
- Clarified that the system has **2 runtime containers** but **3 Docker images** (base image is a build dependency for common image)
- Updated all documentation files (AGENTS.md, README.md, commands.md, architecture.md, sandbox.md, etc.) to reflect the new command and clarify sandbox architecture
- Added troubleshooting entry for updating Mac commands via `refresh-mac-commands.sh`
- Enhanced comments in configuration template explaining the sandbox architecture

### Implementation Details
- Added `scripts/refresh-mac-commands.sh` to allow existing users to update their Mac convenience commands without reinstalling
- Modified `openclaw-orbstack-setup.sh` to clarify build messages and dependencies between sandbox images
- Updated help text and status messages to be more informative about sandbox image rebuilding
- Added note that running containers continue using old images until restart

### Files Modified
- Documentation: AGENTS.md, README.md, docs/README.zh-CN.md, docs/commands.md, docs/architecture.md, docs/sandbox.md, docs/development.md
- Setup scripts: openclaw-orbstack-setup.sh, scripts/refresh-mac-commands.sh (new)
- Configuration template: templates/openclaw.json.example

## Benefits
- Users can now update the application without waiting for sandbox image rebuilds
- Clearer separation of concerns between application updates and sandbox maintenance
- Better documentation of the sandbox architecture reduces confusion
- Existing users can easily refresh their Mac commands without full reinstallation

https://claude.ai/code/session_01GF2XTJfkRav7axXJQASiCN